### PR TITLE
chore: reduce Renovate schedule to weekly on Friday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,7 @@
   ],
   "timezone": "America/Denver",
   "schedule": [
-    "after 10pm every weekday",
-    "before 5am every weekday",
-    "every weekend"
+    "on friday"
   ],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Renovate Dependency Dashboard",


### PR DESCRIPTION
## Summary

- Renovate was running nightly (10pm–5am weekdays) + all weekend
- Every open Renovate PR gets rebased when main advances, triggering a new Netlify deploy preview — with several PRs open this compounds fast
- Switching to once a week on Friday to keep build hours in check

🤖 Generated with [Claude Code](https://claude.com/claude-code)